### PR TITLE
Remove print function in builder

### DIFF
--- a/lib/flutter_toggle_tab.dart
+++ b/lib/flutter_toggle_tab.dart
@@ -131,7 +131,6 @@ class _FlutterToggleTabState extends State<FlutterToggleTab> {
                   : NeverScrollableScrollPhysics(),
               scrollDirection: Axis.horizontal,
               itemBuilder: (context, index) {
-                print("index $index , is null ? ${widget.icons == null}");
                 return ButtonsTab(
                   unSelectedColors: widget.unSelectedBackgroundColors != null
                       ? (widget.unSelectedBackgroundColors.length == 1


### PR DESCRIPTION
Print every change make it unconfortable to use in complex aplications with a lot of logging