### PR TITLE
removed print statement

### DIFF
--- a/lib/flutter_toggle_tab.dart
+++ b/lib/flutter_toggle_tab.dart
@@ -94,7 +94,6 @@ class _FlutterToggleTabState extends State<FlutterToggleTab> {
   @override
   Widget build(BuildContext context) {
     _setDefaultSelected();
-    print("initial ${widget.initialIndex}");
     var width = widget.width != null
         ? widthInPercent(widget.width!, context)
         : widthInPercent(100, context);


### PR DESCRIPTION
The creation of the toggle tab widget prints a line containing "initial 0" during tests. This pollutes the output of my tests which makes them harder to read.