### PR TITLE
I invisibled a right margin in the button tab if only the icon is set.

### DIFF
--- a/lib/button_tab.dart
+++ b/lib/button_tab.dart
@@ -85,7 +85,7 @@ class _ButtonsTabState extends State<ButtonsTab> {
                         )
                       : Container(),
                   Visibility(
-                    visible: widget.icons != null && widget.title != "",
+                    visible: widget.icons != null && widget.title.isNotEmpty,
                     child: SizedBox(
                       width: 4,
                     ),

--- a/lib/button_tab.dart
+++ b/lib/button_tab.dart
@@ -85,7 +85,7 @@ class _ButtonsTabState extends State<ButtonsTab> {
                         )
                       : Container(),
                   Visibility(
-                    visible: widget.icons != null,
+                    visible: widget.icons != null && widget.title != "",
                     child: SizedBox(
                       width: 4,
                     ),


### PR DESCRIPTION
Hi Lzyct,

I noticed that when the button tab has only an icon, there is a visible right margin that throws off the alignment. To address this issue, I have made a simple fix by invisibling the right margin when only the icon is present.

I have tested the changes locally and they work well. Please let me know if you have any questions or concerns about this fix.

Thanks,

Kaedee