### PR TITLE
feat: Support shadow disablement for selected tab

### DIFF
--- a/README.md
+++ b/README.md
@@ -196,6 +196,8 @@ FlutterToggleTab
 | **Alignment** end ***default* : Alignment.bottomCenter**                                    | No         |
 | **bool** isScroll ***default* : true**                                                      | No         |
 | **EdgeInsets** marginSelected ***default* : EdgeInsets.zero**                               | No         |
+| **bool** isShadowEnable ***default* : true**                                                | No         |
+| **bool** isInnerShadowEnable ***default* : true**                                           | No         |
 
 ---
 

--- a/lib/button_tab.dart
+++ b/lib/button_tab.dart
@@ -18,6 +18,7 @@ class ButtonsTab extends StatelessWidget {
   /// [begin] is a begin alignment of the gradient
   /// [end] is an end alignment of the gradient
   /// [marginSelected] is a margin when the button is selected
+  /// [isInnerShadowEnable] is optional to set the shadow of the selected tab.
   const ButtonsTab({
     super.key,
     this.title,
@@ -36,6 +37,7 @@ class ButtonsTab extends StatelessWidget {
     this.begin,
     this.end,
     this.marginSelected = EdgeInsets.zero,
+    this.isInnerShadowEnable = true,
   });
 
   final Widget? counterWidget;
@@ -58,6 +60,7 @@ class ButtonsTab extends StatelessWidget {
   final Alignment? end;
 
   final EdgeInsets? marginSelected;
+  final bool isInnerShadowEnable;
 
   @override
   Widget build(BuildContext context) {
@@ -70,7 +73,8 @@ class ButtonsTab extends StatelessWidget {
             isSelected! ? (marginSelected ?? EdgeInsets.zero) : EdgeInsets.zero,
         child: DecoratedBox(
           decoration: isSelected!
-              ? bdHeader.copyWith(
+              ? (isInnerShadowEnable ? bdHeader : const BoxDecoration())
+                  .copyWith(
                   borderRadius: BorderRadius.circular(radius!),
                   gradient: LinearGradient(
                     // Where the linear gradient begins and ends

--- a/lib/flutter_toggle_tab.dart
+++ b/lib/flutter_toggle_tab.dart
@@ -31,6 +31,7 @@ class FlutterToggleTab extends StatefulWidget {
   ///
   /// [marginSelected] is optional to set the margin of the selected label.
   /// [isShadowEnable] is optional to set the shadow of the widget.
+  /// [isInnerShadowEnable] is optional to set the shadow of the selected tab.
   const FlutterToggleTab({
     super.key,
     required this.dataTabs,
@@ -49,6 +50,7 @@ class FlutterToggleTab extends StatefulWidget {
     this.isScroll = true,
     this.marginSelected,
     this.isShadowEnable = true,
+    this.isInnerShadowEnable = true,
   });
 
   final double? iconSize;
@@ -71,6 +73,7 @@ class FlutterToggleTab extends StatefulWidget {
 
   final EdgeInsets? marginSelected;
   final bool isShadowEnable;
+  final bool isInnerShadowEnable;
 
   @override
   _FlutterToggleTabState createState() => _FlutterToggleTabState();
@@ -199,6 +202,7 @@ class _FlutterToggleTabState extends State<FlutterToggleTab> {
                         icons: icon,
                         iconSize: widget.iconSize,
                         counterWidget: labels[index].counterWidget,
+                        isInnerShadowEnable: widget.isInnerShadowEnable,
 
                         /// default selectedTextStyle is Theme.of(context).textTheme.bodyMedium
                         selectedTextStyle: widget.selectedTextStyle ??


### PR DESCRIPTION
## What

Add `isInnerShadowEnable` property to manage box shadow of selected tab.

## Why

Hi, @Lzyct, thank you for your great library!! I use flutter_toggle_tab in my project. But I want to disable box shadow of the selected tab. So I want to add property to manage box shadow of selected tab for disablement.

## How

Introduce isInnerShadowEnable to FlutterToggleTab and ButtonTab class. Then doesn't use bdHeader that is the box shadow of the selected tab is isInnerShadowEnable is false.

Could you please review and merge it if you accept my idea ? @Lzyct